### PR TITLE
add include_remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ passobj(3, 1, [:t, :u, :v])
 @passobj 1 workers() Foo.foo
 #Or
 passobj(1, workers(), [:foo]; from_mod=Foo)
+
+# Include a file on a path not available on a remote worker
+include_remote(path, 2)
 ```
 
 ## Performance Note

--- a/src/ParallelDataTransfer.jl
+++ b/src/ParallelDataTransfer.jl
@@ -74,17 +74,17 @@ module ParallelDataTransfer
   end
 
   """
-    include_remote(path, [workers=workers()])
+    include_remote(path, [workers=workers()]; module=Main)
   Includes a file which is not available on a remote worker by reading the file at the main node, parsing the text and evaluating the code on the remote workers listed in `workers`
   """
-  function include_remote(path, workers=workers())
+  function include_remote(path, workers=workers(); mod=Main)
       open(path) do f
           text = read(f, String)
           s    = 1
           while s <= length(text)
               ex, s = Meta.parse(text, s)
               for w in workers
-                  @spawnat w @eval $ex
+                  @spawnat w Core.eval(mod, ex)
               end
           end
       end

--- a/src/ParallelDataTransfer.jl
+++ b/src/ParallelDataTransfer.jl
@@ -73,6 +73,24 @@ module ParallelDataTransfer
      end
   end
 
+  """
+    include_remote(path, [workers=workers()])
+  Includes a file which is not available on a remote worker by reading the file at the main node, parsing the text and evaluating the code on the remote workers listed in `workers`
+  """
+  function include_remote(path, workers=workers())
+      open(path) do f
+          text = readstring(f)
+          s    = 1
+          while s <= length(text)
+              ex, s = parse(text, s)
+              for w in workers
+                  @spawnat w @eval $ex
+              end
+          end
+      end
+  end
+
+
   export sendtosimple, @sendto, sendto, getfrom, passobj,
-         @broadcast, @getfrom, @passobj, @defineat
+         @broadcast, @getfrom, @passobj, @defineat, include_remote
 end # module

--- a/src/ParallelDataTransfer.jl
+++ b/src/ParallelDataTransfer.jl
@@ -79,10 +79,10 @@ module ParallelDataTransfer
   """
   function include_remote(path, workers=workers())
       open(path) do f
-          text = readstring(f)
+          text = read(f, String)
           s    = 1
           while s <= length(text)
-              ex, s = parse(text, s)
+              ex, s = Meta.parse(text, s)
               for w in workers
                   @spawnat w @eval $ex
               end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,3 +83,20 @@ mybar_3c1 = remotecall_fetch(()->Main.bar_vec[3].c,2)
 @test mybar_3c1 == ones(3)
 mybar_3c2 = @getfrom(2,bar_vec[3].c)
 @test mybar_3c2 == ones(3)
+
+path, io = mktemp() # Create temp file and store some definitions
+println(io, "__f(x) = x")
+println(io, "__g(x) = x")
+close(io)
+
+w = workers()
+include_remote(path, w[1]) # Include file at remote
+@test remotecall_fetch(()->isdefined(:__f), w[1])
+@test remotecall_fetch(()->isdefined(:__g), w[1])
+@test remotecall_fetch(()->!isdefined(:__f), w[2])
+include_remote(path, w) # Include on all remotes
+for w in w
+    @test remotecall_fetch(()->isdefined(:__f), w)
+    @test remotecall_fetch(()->isdefined(:__g), w)
+end
+rm(path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,12 +91,12 @@ close(io)
 
 w = workers()
 include_remote(path, w[1]) # Include file at remote
-@test remotecall_fetch(()->isdefined(:__f), w[1])
-@test remotecall_fetch(()->isdefined(:__g), w[1])
-@test remotecall_fetch(()->!isdefined(:__f), w[2])
+@test remotecall_fetch(()->@isdefined(__f), w[1])
+@test remotecall_fetch(()->@isdefined(__g), w[1])
+@test remotecall_fetch(()->!@isdefined(__f), w[2])
 include_remote(path, w) # Include on all remotes
 for w in w
-    @test remotecall_fetch(()->isdefined(:__f), w)
-    @test remotecall_fetch(()->isdefined(:__g), w)
+    @test remotecall_fetch(()->@isdefined(__f), w)
+    @test remotecall_fetch(()->@isdefined(__g), w)
 end
 rm(path)


### PR DESCRIPTION
Includes a file which is not available on a remote worker by reading the file at the main node, parsing the text and evaluating the code on the remote worker[s]